### PR TITLE
Atomic sections

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,5 +67,7 @@ target_link_libraries(symdivine ${Z3_LIBRARIES})
 add_definitions("-std=c++11")
 set_property(TARGET symdivine PROPERTY CXX_STANDARD 11)
 set_property(TARGET symdivine PROPERTY CXX_STANDARD_REQUIRED ON)
+set_property(TARGET symdivine APPEND_STRING PROPERTY COMPILE_FLAGS -Wall)
+
 #set(CMAKE_BUILD_TYPE Release)
 

--- a/SymDivine_Vojta/SymDivine_Vojta-Debug.vgdbsettings
+++ b/SymDivine_Vojta/SymDivine_Vojta-Debug.vgdbsettings
@@ -163,7 +163,7 @@
     <LaunchGDBSettings xsi:type="GDBLaunchParametersNewInstance">
       <DebuggedProgram>$(RemoteSourceDir)/bin/symdivine</DebuggedProgram>
       <GDBServerPort>2000</GDBServerPort>
-      <ProgramArguments>reachability ../sv-comp/sv-benchmarks/c/pthread-ext/11_fmaxsymopt_true-unreach-call.ll</ProgramArguments>
+      <ProgramArguments>reachability ../sv-comp/sv-benchmarks/c/pthread-ext/18_read_write_lock_true-unreach-call.ll</ProgramArguments>
       <WorkingDirectory>$(BuildDir)</WorkingDirectory>
     </LaunchGDBSettings>
     <GenerateCtrlBreakInsteadOfCtrlC>false</GenerateCtrlBreakInsteadOfCtrlC>

--- a/SymDivine_Vojta/SymDivine_Vojta-Debug.vgdbsettings
+++ b/SymDivine_Vojta/SymDivine_Vojta-Debug.vgdbsettings
@@ -163,7 +163,7 @@
     <LaunchGDBSettings xsi:type="GDBLaunchParametersNewInstance">
       <DebuggedProgram>$(RemoteSourceDir)/bin/symdivine</DebuggedProgram>
       <GDBServerPort>2000</GDBServerPort>
-      <ProgramArguments>reachability ./test_programs/sv_comp_err/gcd_err_min.ll</ProgramArguments>
+      <ProgramArguments>reachability ../sv-comp/sv-benchmarks/c/pthread-atomic/gcd_true-unreach-call_true-termination.ll</ProgramArguments>
       <WorkingDirectory>$(BuildDir)</WorkingDirectory>
     </LaunchGDBSettings>
     <GenerateCtrlBreakInsteadOfCtrlC>false</GenerateCtrlBreakInsteadOfCtrlC>
@@ -198,7 +198,7 @@
     <CXXFLAGS />
     <ExternalSourceFileList />
     <ExtraSettings>
-      <HideErrorsInSystemHeaders>false</HideErrorsInSystemHeaders>
+      <HideErrorsInSystemHeaders>true</HideErrorsInSystemHeaders>
     </ExtraSettings>
   </CodeSense>
 </VisualGDBProjectSettings2>

--- a/SymDivine_Vojta/SymDivine_Vojta-Debug.vgdbsettings
+++ b/SymDivine_Vojta/SymDivine_Vojta-Debug.vgdbsettings
@@ -163,7 +163,7 @@
     <LaunchGDBSettings xsi:type="GDBLaunchParametersNewInstance">
       <DebuggedProgram>$(RemoteSourceDir)/bin/symdivine</DebuggedProgram>
       <GDBServerPort>2000</GDBServerPort>
-      <ProgramArguments>reachability ../sv-comp/sv-benchmarks/c/pthread-ext/18_read_write_lock_true-unreach-call.ll</ProgramArguments>
+      <ProgramArguments>reachability ./test_programs/sv_comp_err/gcd_err_min.ll</ProgramArguments>
       <WorkingDirectory>$(BuildDir)</WorkingDirectory>
     </LaunchGDBSettings>
     <GenerateCtrlBreakInsteadOfCtrlC>false</GenerateCtrlBreakInsteadOfCtrlC>

--- a/interesting_benchmarks.md
+++ b/interesting_benchmarks.md
@@ -1,0 +1,11 @@
+# List of interesting tests
+
+This document contains all the interesting, weird, suspicious and others benchmarks in context SymDIVINE.
+
+## SV-COMP benchmarks
+
+These tests are marked as false by SymDIVINE, however they are marked as true:
+
+- `pthread/stack_true-unreach-call.c`
+- `pthread/stack_longest_true-unreach-call.c`
+- `pthread/stack_longer_true-unreach-call.i`

--- a/src/llvmsym/blobing.h
+++ b/src/llvmsym/blobing.h
@@ -28,11 +28,11 @@ struct Blob {
         return *((T*)getUser());
     }
 
-    Blob(size_t s, size_t e_s, size_t user_s = 0) : size(s), mem(new char[s]),
-        refcount(new size_t(1)), explicit_size(e_s), user_size(user_s) {}
+	Blob(size_t s, size_t e_s, size_t user_s = 0) : mem(new char[s]), refcount(new size_t(1)),
+        size(s), user_size(user_s), explicit_size(e_s) {}
 
-    Blob(const Blob &snd) : size(snd.size), mem(snd.mem),
-        refcount(snd.refcount), explicit_size(snd.explicit_size), user_size(snd.user_size)
+    Blob(const Blob &snd) : mem(snd.mem), refcount(snd.refcount), size(snd.size),
+        user_size(snd.user_size), explicit_size(snd.explicit_size)
     {
         ++*refcount;
     }

--- a/src/llvmsym/evaluator.h
+++ b/src/llvmsym/evaluator.h
@@ -456,6 +456,14 @@ class Evaluator : Dispatcher< Evaluator< DataStore > >{
                 do_mutex_unlock(ci->getArgOperand(0), tid);
                 yield(!amILonelyThread(), false, true);
             }
+            else if (fun_name == "__VERIFIER_atomic_begin") {
+                state.control.enter_atomic_section(tid);
+                yield(!amILonelyThread(), false, true);
+            }
+            else if (fun_name == "__VERIFIER_atomic_end") {
+                state.control.leave_atomic_section(tid);
+                yield(!amILonelyThread(), false, true);
+            }
             else if (fun_name == "llvm.dbg.declare") {
                 // ignore llvm dbg functions
             }

--- a/src/llvmsym/formula/rpn.h
+++ b/src/llvmsym/formula/rpn.h
@@ -132,7 +132,7 @@ struct Formula {
                         case LEq:   return " <= ";
                         case ULEq:   return " <= ";
                         case GT:    return " > ";
-                        case UGT:   return " >= ";
+                        case UGT:   return " > ";
                         case GEq:   return " >= ";
                         case UGEq:   return " >= ";
                         case BAnd:   return " & ";
@@ -173,7 +173,7 @@ struct Formula {
             return "";
         }
 
-      std::string print( std::map< Ident, unsigned > &m ) {
+      std::string print( std::map< Ident, unsigned > &m ) const {
         std::stringstream ss;
         switch ( kind ) {
         case Op:
@@ -210,14 +210,14 @@ struct Formula {
                     
           }
         case Constant:
-          ss << "0d" << id.bw << "_" << value;
+          ss << "0d" << (int)id.bw << "_" << value;
           return ss.str();
                     
         case Identifier:
           if ( id.gen == 0 )
-            ss << "r" << m[ id ];
+            ss << "r" << m[id];
           else
-            ss << "input [ 0 : " << id.bw <<  "]";
+            ss << "[seg" << id.seg << "_off" << id.off << "]";
           return ss.str();
         case BoolVal:
           if ( value )
@@ -634,7 +634,7 @@ struct Formula {
 
     friend std::ostream &operator<<( std::ostream &o, const Formula &f );
 
-    std::string print( std::map< Ident, unsigned > &m ) {
+    std::string print( std::map< Ident, unsigned > &m ) const {
       std::vector< std::string > stack;
 
       for ( unsigned pos = 0; pos < size(); ++pos ) {

--- a/src/llvmsym/ltl.tpp
+++ b/src/llvmsym/ltl.tpp
@@ -157,7 +157,7 @@ bool Ltl<Store, Hit>::run_inner_dfs(StateId start_vertex) {
 			info.inner_color = VertexColor::GRAY;
 		}
 		else if (info.inner_color == VertexColor::GRAY) {
-			info.inner_color == VertexColor::BLACK;
+			info.inner_color = VertexColor::BLACK;
 			to_process.pop();
 		}
 		else if (info.inner_color == VertexColor::BLACK) {

--- a/src/llvmsym/memorylayout.cpp
+++ b/src/llvmsym/memorylayout.cpp
@@ -4,12 +4,42 @@ namespace llvm_sym {
 
 std::ostream & operator<<( std::ostream & o, const MemoryLayout &m )
 {
-    for ( unsigned i = 0; i < m.thread_segments.size(); ++i ) {
+    /*for ( unsigned i = 0; i < m.thread_segments.size(); ++i ) {
         o << "tid " << i << " segments:\n";
         for ( auto j : m.thread_segments[i] )
             o << j << std::endl;
+    }*/
+    std::cout << m.global_valuemap->size() << "\n";
+    for (const auto& pair : *(m.global_valuemap)) {
+        pair.first->dump();
     }
     return o;
+}
+    
+void MemoryLayout::dump() const {
+    std::cout << "Globals:\n";
+    for (const auto& pair : *global_valuemap) {
+        std::cout << "\t";
+        pair.first->dump();
+        std::cout << "\n";
+    }
+    
+    int count = 0;
+    for (const auto& frames : current_frames) {
+        std::cerr << "thread " << count << ":\n";
+        std::vector<std::pair<const llvm::Value*, ValueInfo>> o;
+        for (const auto& pair : frames->valuemap) {
+            o.push_back(pair);
+        }
+        std::sort(o.begin(), o.end(), [](const std::pair<const llvm::Value*, ValueInfo>& a, const std::pair<const llvm::Value*, ValueInfo>& b) {
+            return a.second.id < b.second.id;
+        });
+        for (const auto& pair : o) {
+            std::cerr << "Offset " << pair.second.id << ": ";
+            pair.first->dump();
+        }
+        count++;
+    }
 }
 
 void MemoryLayout::leave( unsigned tid )

--- a/src/llvmsym/memorylayout.h
+++ b/src/llvmsym/memorylayout.h
@@ -236,6 +236,8 @@ class MemoryLayout {
     {
         return representation_size( thread_segments, segments_in_stack, variablesFlags );
     }
+    
+    void dump() const;
 
 
     friend std::ostream & operator<<( std::ostream & o, const MemoryLayout &m );

--- a/src/llvmsym/properties.h
+++ b/src/llvmsym/properties.h
@@ -3,34 +3,23 @@
 
 namespace llvm_sym {
 
-class Properties {
-    bool _error = false;
-
-public:
-
-    bool isError() const
-    {
-        return _error;
-    }
-
-    void setError( bool val )
-    {
-        _error = val;
-    }
+struct Properties {
+    bool error = false;
+    bool empty = false;
 
     size_t getSize() const
     {
-        return representation_size( _error );
+        return representation_size(error, empty);
     }
 
-    void writeData( char * &mem ) const
+    void writeData(char * &mem) const
     {
-        blobWrite( mem, _error );
+        blobWrite(mem, error, empty);
     }
 
-    void readData( const char * &mem )
+    void readData(const char * &mem)
     {
-        blobRead( mem, _error );
+        blobRead(mem, error, empty);
     }
 
 };

--- a/src/llvmsym/reachability.tpp
+++ b/src/llvmsym/reachability.tpp
@@ -35,9 +35,10 @@ void Reachability<Store, Hit>::run() {
                 Blob newSucc(eval.getSize(), eval.getExplicitSize());
                 eval.write(newSucc.getExpl());
 
-                if (eval.isError()) {
-                    std::cout << "Error state:\n" << eval.toString() << "is reachable."
-                        << std::endl;
+                if (eval.is_error() && !eval.is_empty()) {
+                    std::cout << "Error state:\n";
+                    eval.dump();
+                    std::cout << "is reachable." << std::endl;
                     error_found = true;
                 }
 

--- a/src/llvmsym/smtdatastore.cpp
+++ b/src/llvmsym/smtdatastore.cpp
@@ -89,7 +89,7 @@ bool SMTStore::subseteq(
     z3::params p(c);
     p.set(":mbqi", true);
     if (!Config.is_set("--disabletimeout")) {
-        p.set("SOFT_TIMEOUT", timeout);
+        //p.set("timeout", timeout);
     }
     s.set(p);
     

--- a/src/llvmsym/smtdatastore.cpp
+++ b/src/llvmsym/smtdatastore.cpp
@@ -36,11 +36,13 @@ bool SMTStore::empty() const
 
     z3::solver s( c );
     for (const auto& group : sym_data) {
-        for (const Definition &def : group.second.definitions)
+        for (const Definition &def : group.second.definitions) {
             s.add(toz3(def.to_formula(), 'a', c));
+        }
 
-        for (const Formula &pc : group.second.path_condition)
+        for (const Formula &pc : group.second.path_condition) {
             s.add(toz3(pc, 'a', c));
+        }
     }
 
     ++Statistics::getCounter( STAT_SMT_CALLS );

--- a/src/llvmsym/smtdatastore.h
+++ b/src/llvmsym/smtdatastore.h
@@ -507,7 +507,9 @@ class SMTStore : public DataStore {
     virtual void prune( Value a, Value b, ICmp_Op op )
     {
         Formula a_expr = build_expression( a );
+        std::cout << "Formula a: " << a_expr << "\n";
         Formula b_expr = build_expression( b );
+        std::cout << "Formula b: " << b_expr << "\n";
         switch ( op ) {
             case ICmp_Op::EQ:
                 pushCondition( a_expr == b_expr );

--- a/src/llvmsym/smtdatastore.h
+++ b/src/llvmsym/smtdatastore.h
@@ -507,9 +507,7 @@ class SMTStore : public DataStore {
     virtual void prune( Value a, Value b, ICmp_Op op )
     {
         Formula a_expr = build_expression( a );
-        std::cout << "Formula a: " << a_expr << "\n";
         Formula b_expr = build_expression( b );
-        std::cout << "Formula b: " << b_expr << "\n";
         switch ( op ) {
             case ICmp_Op::EQ:
                 pushCondition( a_expr == b_expr );

--- a/src/llvmsym/thread.cpp
+++ b/src/llvmsym/thread.cpp
@@ -6,14 +6,15 @@ namespace llvm_sym {
 std::ostream & operator<<( std::ostream &o, const Control &c )
 {
     for ( unsigned tid = 0; tid < c.threadCount(); ++tid ) {
-        o << "thread " << tid << '\n';
+        o << "thread " << tid << ": ";
         
         for ( const Control::PC &p : c.context[tid] ) {
-            o << '{'
-              << p.function << ", "
-              << p.basicblock << ", "
-              << p.instruction << "}\n";
+            o << "{ func: "
+              << p.function << ", block: "
+              << p.basicblock << ", inst: "
+              << p.instruction << "}, ";
         }
+        o << "\n";
     }
 
 

--- a/src/llvmsym/thread.h
+++ b/src/llvmsym/thread.h
@@ -146,11 +146,13 @@ struct Control {
     
     void enter_atomic_section(size_t tid) {
         assert(tid < context.size());
+        std::cout << "Entering atomic section\n";
         atomic_section.push_back(tid);
     }
     
     void leave_atomic_section(size_t tid) {
         assert(!atomic_section.empty() && atomic_section.back() == tid);
+        std::cout << "Leaving atomic section\n";
         atomic_section.pop_back();
     }
     

--- a/src/llvmsym/thread.h
+++ b/src/llvmsym/thread.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <llvmsym/blobutils.h>
 #include <cassert>
-#include <ostream>
+#include <iostream>
 #include <boost/iterator/counting_iterator.hpp>
 
 namespace llvm_sym {
@@ -30,13 +30,13 @@ struct Control {
 
     void writeData( char * &mem ) const
     {
-        blobWrite( mem, context, previous_bb, tids, next_free_tid );
+        blobWrite( mem, context, previous_bb, tids, next_free_tid, atomic_section );
     }
 
     void readData( const char * &mem )
     {
         context.clear();
-        blobRead( mem, context, previous_bb, tids, next_free_tid );
+        blobRead( mem, context, previous_bb, tids, next_free_tid, atomic_section );
 
         assert( context.size() == previous_bb.size() && context.size() == tids.size() );
     }
@@ -56,7 +56,7 @@ struct Control {
 
     size_t getSize() const
     {
-        return representation_size( context, previous_bb, tids, next_free_tid );
+        return representation_size( context, previous_bb, tids, next_free_tid, atomic_section );
     }
 
     // returns tid
@@ -157,10 +157,12 @@ struct Control {
     std::vector<size_t> get_allowed_threads() const {
         if (atomic_section.empty()) {
             // Allow all threads
-            return std::vector<size_t>(
+            auto ret = std::vector<size_t>(
                 boost::counting_iterator<size_t>(0),
                 boost::counting_iterator<size_t>(context.size())
                 );
+            
+            return ret;
         }
         // Allow only single thread
         return std::vector<size_t>({ atomic_section.back() });

--- a/src/llvmsym/thread.h
+++ b/src/llvmsym/thread.h
@@ -146,13 +146,11 @@ struct Control {
     
     void enter_atomic_section(size_t tid) {
         assert(tid < context.size());
-        std::cout << "Entering atomic section\n";
         atomic_section.push_back(tid);
     }
     
     void leave_atomic_section(size_t tid) {
         assert(!atomic_section.empty() && atomic_section.back() == tid);
-        std::cout << "Leaving atomic section\n";
         atomic_section.pop_back();
     }
     

--- a/src/toolkit/ltl2ba.h
+++ b/src/toolkit/ltl2ba.h
@@ -92,6 +92,8 @@ public:
         dp.property("label", boost::get(&DotEdge::label, graphviz));
 
         bool status = boost::read_graphviz(dot, graphviz, dp);
+        if (!status)
+            throw LtlConvException("Cannot read ltl2ba output");
 
         // Convert BA to Graph class
         typedef typename boost::property_map<graph_t, boost::vertex_index_t>::type IndexMap;


### PR DESCRIPTION
SV-COMP requires functional atomic sections for some benchmarks:
- functions with prefix `__VERIFIER_atomic_` are considered as atomic
- atomic section can be entered via calling `__VERIFIER_atomic_start()` and be leaved via `__VERIFIER_atomic_end()`

Implementation:
- `Control` structure contains stack of threads idx in atomic sections. Note: There will be only one thread in the stack - anything else means error. However the stack or counter is necessary because of nested calls to the atomic functions.
- When the stack is not empty, only one thread is advanced from the current state. 
